### PR TITLE
Add front-end scheduling tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+# Scheduling Tool
+
+A lightweight scheduling dashboard for tracking instructors, the classes they teach, session durations, and assigned rooms. The tool keeps a running tally of total scheduled hours for every instructor.
+
+## Features
+
+- Add class sessions with instructor, class name, duration, and room details.
+- Automatically calculate total scheduled hours per instructor.
+- Remove individual sessions or clear the entire schedule.
+- Responsive layout with support for light and dark themes.
+- Persists data in the browser using `localStorage`.
+
+## Getting Started
+
+1. Open `index.html` in your preferred browser.
+2. Use the **Add Class Session** form to log new class sessions.
+3. Review the **Class Schedule** table for an overview of all sessions.
+4. Track total instructor hours in the **Instructor Hours** section.
+
+No additional build steps or dependencies are required.
+
+## Development Notes
+
+- All logic lives in `script.js`, which handles validation, rendering, and persistence.
+- Styling is provided by `styles.css` and includes dark-mode adjustments via the `prefers-color-scheme` media query.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,159 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Scheduling Tool</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header>
+      <h1>Instructor Scheduling Tool</h1>
+      <p class="tagline">
+        Track classes, rooms, and instructor hours in one convenient view.
+      </p>
+    </header>
+
+    <main>
+      <section class="card" aria-labelledby="add-schedule-heading">
+        <div class="card-header">
+          <h2 id="add-schedule-heading">Add Class Session</h2>
+          <p class="helper-text">
+            Provide the instructor, class title, duration (in hours), and the room.
+          </p>
+        </div>
+        <form id="schedule-form" novalidate>
+          <div class="form-grid">
+            <label class="form-field">
+              <span>Instructor<span aria-hidden="true">*</span></span>
+              <input
+                type="text"
+                id="instructor"
+                name="instructor"
+                required
+                placeholder="e.g., Alex Johnson"
+                autocomplete="off"
+              />
+              <small class="error" data-error-for="instructor"></small>
+            </label>
+
+            <label class="form-field">
+              <span>Class<span aria-hidden="true">*</span></span>
+              <input
+                type="text"
+                id="className"
+                name="className"
+                required
+                placeholder="e.g., Intro to Pottery"
+                autocomplete="off"
+              />
+              <small class="error" data-error-for="className"></small>
+            </label>
+
+            <label class="form-field">
+              <span>Duration (hours)<span aria-hidden="true">*</span></span>
+              <input
+                type="number"
+                id="duration"
+                name="duration"
+                required
+                min="0.25"
+                step="0.25"
+                placeholder="e.g., 1.5"
+              />
+              <small class="error" data-error-for="duration"></small>
+            </label>
+
+            <label class="form-field">
+              <span>Room<span aria-hidden="true">*</span></span>
+              <input
+                type="text"
+                id="room"
+                name="room"
+                required
+                placeholder="e.g., Studio B"
+                autocomplete="off"
+              />
+              <small class="error" data-error-for="room"></small>
+            </label>
+          </div>
+
+          <div class="actions">
+            <button type="submit" class="primary">Add to Schedule</button>
+            <button type="button" class="secondary" id="clear-all">Clear All</button>
+          </div>
+        </form>
+      </section>
+
+      <section class="card" aria-labelledby="schedule-heading">
+        <div class="card-header">
+          <h2 id="schedule-heading">Class Schedule</h2>
+          <p class="helper-text">
+            Review upcoming sessions, organized by instructor and room.
+          </p>
+        </div>
+        <div class="table-container">
+          <table id="schedule-table">
+            <thead>
+              <tr>
+                <th scope="col">Instructor</th>
+                <th scope="col">Class</th>
+                <th scope="col">Duration (hrs)</th>
+                <th scope="col">Room</th>
+                <th scope="col" class="actions-column">Actions</th>
+              </tr>
+            </thead>
+            <tbody></tbody>
+          </table>
+          <p id="empty-state" class="empty-state">No sessions scheduled yet.</p>
+        </div>
+      </section>
+
+      <section class="card" aria-labelledby="instructor-hours-heading">
+        <div class="card-header">
+          <h2 id="instructor-hours-heading">Instructor Hours</h2>
+          <p class="helper-text">
+            Total scheduled hours are automatically calculated for each instructor.
+          </p>
+        </div>
+        <div class="table-container">
+          <table id="hours-table">
+            <thead>
+              <tr>
+                <th scope="col">Instructor</th>
+                <th scope="col">Total Hours</th>
+              </tr>
+            </thead>
+            <tbody></tbody>
+          </table>
+          <p id="hours-empty-state" class="empty-state">No instructor hours to display.</p>
+        </div>
+      </section>
+    </main>
+
+    <footer>
+      <p>Built to simplify class scheduling and instructor management.</p>
+    </footer>
+
+    <template id="schedule-row-template">
+      <tr>
+        <td data-field="instructor"></td>
+        <td data-field="className"></td>
+        <td data-field="duration"></td>
+        <td data-field="room"></td>
+        <td class="actions-column">
+          <button type="button" class="link" data-action="delete">Remove</button>
+        </td>
+      </tr>
+    </template>
+
+    <template id="hours-row-template">
+      <tr>
+        <td data-field="instructor"></td>
+        <td data-field="total"></td>
+      </tr>
+    </template>
+
+    <script src="script.js" defer></script>
+  </body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,229 @@
+(() => {
+  const STORAGE_KEY = "scheduleEntries";
+  const numberFormatter = new Intl.NumberFormat(undefined, {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 2,
+  });
+
+  const form = document.getElementById("schedule-form");
+  const clearAllButton = document.getElementById("clear-all");
+  const tableBody = document.querySelector("#schedule-table tbody");
+  const hoursTableBody = document.querySelector("#hours-table tbody");
+  const emptyState = document.getElementById("empty-state");
+  const hoursEmptyState = document.getElementById("hours-empty-state");
+  const scheduleRowTemplate = document.getElementById("schedule-row-template");
+  const hoursRowTemplate = document.getElementById("hours-row-template");
+
+  let scheduleEntries = loadSchedule();
+  render();
+
+  form.addEventListener("submit", (event) => {
+    event.preventDefault();
+
+    const formData = new FormData(form);
+    const instructor = formData.get("instructor").trim();
+    const className = formData.get("className").trim();
+    const durationRaw = formData.get("duration");
+    const room = formData.get("room").trim();
+
+    clearErrors();
+
+    const errors = {};
+    if (!instructor) {
+      errors.instructor = "Instructor name is required.";
+    }
+    if (!className) {
+      errors.className = "Class name is required.";
+    }
+
+    const duration = Number.parseFloat(durationRaw);
+    if (!Number.isFinite(duration) || duration <= 0) {
+      errors.duration = "Duration must be a positive number.";
+    }
+
+    if (!room) {
+      errors.room = "Room is required.";
+    }
+
+    if (Object.keys(errors).length > 0) {
+      displayErrors(errors);
+      return;
+    }
+
+    scheduleEntries.push({
+      id: crypto.randomUUID(),
+      instructor,
+      className,
+      duration,
+      room,
+    });
+
+    saveSchedule();
+    render();
+    form.reset();
+    form.elements["instructor"].focus();
+  });
+
+  clearAllButton.addEventListener("click", () => {
+    if (scheduleEntries.length === 0) {
+      return;
+    }
+
+    const confirmed = window.confirm(
+      "This will remove all scheduled sessions. Do you want to continue?"
+    );
+
+    if (!confirmed) {
+      return;
+    }
+
+    scheduleEntries = [];
+    saveSchedule();
+    render();
+  });
+
+  tableBody.addEventListener("click", (event) => {
+    const button = event.target.closest("[data-action='delete']");
+    if (!button) {
+      return;
+    }
+
+    const row = button.closest("tr");
+    const { id } = row.dataset;
+
+    scheduleEntries = scheduleEntries.filter((entry) => entry.id !== id);
+    saveSchedule();
+    render();
+  });
+
+  form.querySelectorAll("input").forEach((input) => {
+    input.addEventListener("input", () => {
+      const errorElement = form.querySelector(
+        `.error[data-error-for="${input.name}"]`
+      );
+      if (errorElement && errorElement.textContent) {
+        errorElement.textContent = "";
+      }
+    });
+  });
+
+  function render() {
+    renderScheduleTable();
+    renderInstructorHours();
+  }
+
+  function renderScheduleTable() {
+    tableBody.innerHTML = "";
+
+    if (scheduleEntries.length === 0) {
+      emptyState.hidden = false;
+      return;
+    }
+
+    emptyState.hidden = true;
+
+    scheduleEntries.forEach((entry) => {
+      const row = scheduleRowTemplate.content
+        .firstElementChild.cloneNode(true);
+
+      row.dataset.id = entry.id;
+      row.querySelector('[data-field="instructor"]').textContent =
+        entry.instructor;
+      row.querySelector('[data-field="className"]').textContent =
+        entry.className;
+      row.querySelector('[data-field="duration"]').textContent =
+        numberFormatter.format(entry.duration);
+      row.querySelector('[data-field="room"]').textContent = entry.room;
+
+      tableBody.appendChild(row);
+    });
+  }
+
+  function renderInstructorHours() {
+    hoursTableBody.innerHTML = "";
+
+    if (scheduleEntries.length === 0) {
+      hoursEmptyState.hidden = false;
+      return;
+    }
+
+    hoursEmptyState.hidden = true;
+
+    const totals = scheduleEntries.reduce((acc, entry) => {
+      const key = entry.instructor.toLowerCase();
+      const displayName = entry.instructor;
+      if (!acc[key]) {
+        acc[key] = { instructor: displayName, total: 0 };
+      }
+      acc[key].total += entry.duration;
+      return acc;
+    }, {});
+
+    const sortedTotals = Object.values(totals).sort((a, b) =>
+      a.instructor.localeCompare(b.instructor, undefined, { sensitivity: "base" })
+    );
+
+    sortedTotals.forEach((item) => {
+      const row = hoursRowTemplate.content
+        .firstElementChild.cloneNode(true);
+      row.querySelector('[data-field="instructor"]').textContent =
+        item.instructor;
+      row.querySelector('[data-field="total"]').textContent =
+        numberFormatter.format(item.total);
+      hoursTableBody.appendChild(row);
+    });
+  }
+
+  function clearErrors() {
+    form.querySelectorAll(".error").forEach((el) => {
+      el.textContent = "";
+    });
+  }
+
+  function displayErrors(errors) {
+    Object.entries(errors).forEach(([field, message]) => {
+      const errorElement = form.querySelector(
+        `.error[data-error-for="${field}"]`
+      );
+      if (errorElement) {
+        errorElement.textContent = message;
+      }
+    });
+  }
+
+  function loadSchedule() {
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY);
+      if (!stored) {
+        return [];
+      }
+      const parsed = JSON.parse(stored);
+      if (!Array.isArray(parsed)) {
+        return [];
+      }
+      return parsed.filter(isValidEntry);
+    } catch (error) {
+      console.warn("Unable to load schedule from storage", error);
+      return [];
+    }
+  }
+
+  function saveSchedule() {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(scheduleEntries));
+  }
+
+  function isValidEntry(candidate) {
+    if (typeof candidate !== "object" || candidate === null) {
+      return false;
+    }
+    const { id, instructor, className, duration, room } = candidate;
+    return (
+      typeof id === "string" &&
+      typeof instructor === "string" &&
+      typeof className === "string" &&
+      typeof room === "string" &&
+      typeof duration === "number" &&
+      Number.isFinite(duration)
+    );
+  }
+})();

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,257 @@
+:root {
+  color-scheme: light dark;
+  --color-background: #f4f6fb;
+  --color-surface: #ffffff;
+  --color-border: #d6d9e0;
+  --color-primary: #1a73e8;
+  --color-primary-dark: #1557b0;
+  --color-text: #1f2937;
+  --color-text-subtle: #4b5563;
+  --color-danger: #b91c1c;
+  font-family: "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(circle at top, #f0f4ff, #fdfdfd 60%);
+  color: var(--color-text);
+  line-height: 1.6;
+  display: flex;
+  flex-direction: column;
+}
+
+header,
+footer {
+  text-align: center;
+  padding: 2rem 1rem;
+}
+
+header {
+  background: linear-gradient(135deg, rgba(26, 115, 232, 0.1), rgba(26, 115, 232, 0.02));
+  border-bottom: 1px solid var(--color-border);
+}
+
+h1 {
+  margin: 0 0 0.5rem;
+  font-size: clamp(2rem, 3vw, 2.5rem);
+}
+
+.tagline {
+  margin: 0;
+  color: var(--color-text-subtle);
+  font-size: 1.05rem;
+}
+
+main {
+  flex: 1;
+  padding: 2rem 1rem 3rem;
+  max-width: 1100px;
+  margin: 0 auto;
+  display: grid;
+  gap: 1.5rem;
+}
+
+.card {
+  background: var(--color-surface);
+  border-radius: 18px;
+  border: 1px solid rgba(17, 24, 39, 0.08);
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.08);
+  padding: 1.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  backdrop-filter: blur(6px);
+}
+
+.card-header h2 {
+  margin: 0;
+  font-size: 1.5rem;
+}
+
+.helper-text {
+  margin: 0.35rem 0 0;
+  color: var(--color-text-subtle);
+  font-size: 0.95rem;
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.25rem;
+}
+
+.form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  font-size: 0.95rem;
+}
+
+.form-field input {
+  padding: 0.75rem 0.9rem;
+  border-radius: 10px;
+  border: 1px solid var(--color-border);
+  background: rgba(255, 255, 255, 0.85);
+  font-size: 1rem;
+  transition: border-color 0.2s, box-shadow 0.2s;
+}
+
+.form-field input:focus {
+  outline: none;
+  border-color: rgba(26, 115, 232, 0.7);
+  box-shadow: 0 0 0 3px rgba(26, 115, 232, 0.15);
+}
+
+.error {
+  height: 1rem;
+  font-size: 0.8rem;
+  color: var(--color-danger);
+}
+
+.actions {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+button.primary,
+button.secondary,
+button.link {
+  font-weight: 600;
+  border-radius: 999px;
+  border: none;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+button.primary {
+  background: var(--color-primary);
+  color: white;
+  padding: 0.75rem 1.5rem;
+  box-shadow: 0 12px 24px rgba(26, 115, 232, 0.25);
+}
+
+button.primary:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 14px 28px rgba(26, 115, 232, 0.3);
+}
+
+button.secondary {
+  background: rgba(26, 115, 232, 0.08);
+  color: var(--color-primary);
+  padding: 0.75rem 1.5rem;
+  box-shadow: inset 0 0 0 1px rgba(26, 115, 232, 0.2);
+}
+
+button.secondary:hover {
+  transform: translateY(-1px);
+  box-shadow: inset 0 0 0 1px rgba(26, 115, 232, 0.2), 0 6px 16px rgba(26, 115, 232, 0.1);
+}
+
+button.link {
+  background: transparent;
+  color: var(--color-primary);
+  padding: 0.35rem 0.5rem;
+}
+
+button.link:hover {
+  color: var(--color-primary-dark);
+  text-decoration: underline;
+}
+
+.table-container {
+  border: 1px solid rgba(17, 24, 39, 0.08);
+  border-radius: 14px;
+  overflow: hidden;
+  background: rgba(255, 255, 255, 0.9);
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.95rem;
+}
+
+th,
+td {
+  padding: 0.9rem 1rem;
+  text-align: left;
+}
+
+th {
+  background: rgba(26, 115, 232, 0.08);
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+tbody tr:nth-child(even) {
+  background: rgba(148, 163, 184, 0.08);
+}
+
+.empty-state {
+  margin: 0;
+  padding: 1.5rem;
+  text-align: center;
+  color: var(--color-text-subtle);
+}
+
+.actions-column {
+  width: 110px;
+  text-align: center;
+}
+
+footer {
+  font-size: 0.9rem;
+  color: var(--color-text-subtle);
+  background: rgba(17, 24, 39, 0.03);
+  border-top: 1px solid var(--color-border);
+}
+
+@media (max-width: 720px) {
+  main {
+    padding: 1.5rem 1rem 2.5rem;
+  }
+
+  .card {
+    padding: 1.5rem;
+  }
+
+  th,
+  td {
+    padding: 0.75rem 0.85rem;
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --color-background: #0f172a;
+    --color-surface: rgba(15, 23, 42, 0.92);
+    --color-border: rgba(148, 163, 184, 0.35);
+    --color-primary: #60a5fa;
+    --color-primary-dark: #3b82f6;
+    --color-text: #f8fafc;
+    --color-text-subtle: #cbd5f5;
+    --color-danger: #f87171;
+  }
+
+  body {
+    background: radial-gradient(circle at top, #1e293b, #0f172a 70%);
+  }
+
+  .table-container {
+    background: rgba(15, 23, 42, 0.9);
+  }
+
+  tbody tr:nth-child(even) {
+    background: rgba(96, 165, 250, 0.08);
+  }
+
+  th {
+    background: rgba(96, 165, 250, 0.12);
+  }
+}


### PR DESCRIPTION
## Summary
- create responsive single-page interface to add class sessions with instructor, duration, and room details
- compute and display total scheduled hours per instructor with persisted entries in localStorage
- document usage and styling details for the scheduling tool

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e44148bd448321b29494754555b8d6